### PR TITLE
Add support for site-required proxy (see INC0131511)

### DIFF
--- a/sshproxy.sh
+++ b/sshproxy.sh
@@ -215,8 +215,9 @@ tmpkey="$(mktemp $tmpdir/key.XXXXXX)"
 tmpcert="$(mktemp $tmpdir/cert.XXXXXX)"
 tmppub="$(mktemp $tmpdir/pub.XXXXXX)"
 
+siteproxy=${PROXYROOT:+--socks5 $PROXYROOT:${PROXYPORT:-1080}}
 # And get the key/cert
-curl -s -S -X POST https://$url/create_pair/$scope/ \
+curl -s -S $siteproxy -X POST https://$url/create_pair/$scope/ \
 	-o $tmpkey -K - <<< "-u $user:$pw"
 
 # Check for error


### PR DESCRIPTION
addition to use a SOCK5 server if the user has $PROXYROOT set in their environment (to the proxy address)

This is derived from INC0131511, where the user needs to work around a site-required proxy setup
