### PR TITLE
Remind user of username

### DIFF
--- a/sshproxy.sh
+++ b/sshproxy.sh
@@ -201,7 +201,7 @@ pubfile="$idfile.pub"
 # prompt is interrupted by ctrl-c.  Otherwise terminal gets left in
 # a weird state.
 
-read -p "Enter your password+OTP: " -s pw
+read -p "Enter the password+OTP for ${user}: " -s pw
 
 # read -p doesn't output a newline after entry
 printf "\n"


### PR DESCRIPTION
Print the username at the prompt.

I had approximately 15 failed login attempts because sshproxy.sh didn't warn me what username I was trying to get a key for.  This PR reminds the user at the prompt for password+OTP.